### PR TITLE
:bug: (phone) Wrap google lib calls into try/catch block

### DIFF
--- a/src/yup-phone.ts
+++ b/src/yup-phone.ts
@@ -30,24 +30,28 @@ Yup.addMethod(Yup.string, YUP_PHONE_METHOD, function yupPhone(
       strict = false;
     }
 
-    const phoneNumber = phoneUtil.parseAndKeepRawInput(value, countryCode);
+    try {
+      const phoneNumber = phoneUtil.parseAndKeepRawInput(value, countryCode);
 
-    if (!phoneUtil.isPossibleNumber(phoneNumber)) {
-      return false;
-    }
+      if (!phoneUtil.isPossibleNumber(phoneNumber)) {
+        return false;
+      }
 
-    const regionCodeFromPhoneNumber = phoneUtil.getRegionCodeForNumber(
-      phoneNumber,
-    );
+      const regionCodeFromPhoneNumber = phoneUtil.getRegionCodeForNumber(
+        phoneNumber,
+      );
 
     /* check if the countryCode provided should be used as
        default country code or strictly followed
      */
-    return strict
+      return strict
       ? phoneUtil.isValidNumberForRegion(phoneNumber, countryCode)
       : phoneUtil.isValidNumberForRegion(
         phoneNumber,
         regionCodeFromPhoneNumber,
         );
+    } catch {
+      return false;
+    }
   });
 });


### PR DESCRIPTION
While using this library in my project, I suffered this kind of errors:
`Unhandled Promise Rejection: TypeError: yuperror.inner is not an object` 

After some debugging, I've found out that `google-libphonenumber` do throw exceptions when calling `parseAndKeepRawInput` with number.length < 2. It's logic that the phone cannot be shorter than country code.

Wrapping calls with try/catch block helps with that.