### PR TITLE
docs: add correct package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Read more here [*libphonenumber*](https://github.com/googlei18n/libphonenumber/b
 ## Install
 
 ```sh
-# npm install --save yup-phone
-$ yarn add yup-phone
+# npm install --save @fyne/yup-phone
+$ yarn add @fyne/yup-phone
 ```
 
 ## Usage


### PR DESCRIPTION
The following error was return on yarn add yup-phone:
error An unexpected error occurred: "https://registry.yarnpkg.com/yup-phone: Not found".

Changing the import fixes this