### PR TITLE
Using .required('This field is required') is cleaner than invalidating…

### DIFF
--- a/src/yup-phone.ts
+++ b/src/yup-phone.ts
@@ -46,6 +46,9 @@ Yup.addMethod(Yup.string, YUP_PHONE_METHOD, function yupPhone(
       strict = false;
     }
 
+    // This is what .required() is for
+    if (!value || ((typeof(value) == 'string') && value.length == 0)) return true
+
     try {
       const phoneNumber = phoneUtil.parseAndKeepRawInput(value, countryCode);
 


### PR DESCRIPTION
This change allows .phone() to validate true so that .required can explain it's a required field. Example...

```
    phone: Yup
        .string()
        .phone('US', true, 'Phone number is not valid'),
        .required('Phone number is a required field')
```

