### PR TITLE
Carl certifyos/fix for not required phone field

### DIFF
--- a/src/yup-phone.ts
+++ b/src/yup-phone.ts
@@ -40,6 +40,11 @@ Yup.addMethod(Yup.string, YUP_PHONE_METHOD, function yupPhone(
       : '${path} must be a valid phone number.';
   // @ts-ignore
   return this.test(YUP_PHONE_METHOD, errMsg, (value: string) => {
+    /* For values verified by yup that are not required
+     so that we do not give an error on empty input value
+     */
+    if (!value || !value.length) return true;
+
     if (!isValidCountryCode(countryCode)) {
       // if not valid countryCode, then set default country to India (IN)
       countryCode = 'IN';

--- a/src/yup-phone.ts
+++ b/src/yup-phone.ts
@@ -42,6 +42,7 @@ Yup.addMethod(Yup.string, YUP_PHONE_METHOD, function yupPhone(
   return this.test(YUP_PHONE_METHOD, errMsg, (value: string) => {
     /* For values verified by yup that are not required
      so that we do not give an error on empty input value
+     the yup .reqired() function can handle if the field is required.
      */
     if (!value || !value.length) return true;
 


### PR DESCRIPTION
I find that for phone number fields that are not required, when the field is empty an error is displayed.

Allowing empty field without an error.  Allow the yup .required() to give the error on empty if the field is required.